### PR TITLE
Fix addSecondFractions failing when subtracting whole multiples of 1.0

### DIFF
--- a/Data/UTC/Class/IsTime.hs
+++ b/Data/UTC/Class/IsTime.hs
@@ -82,6 +82,7 @@ class IsTime t where
   addSecondFractions f t
     | f == 0    = return t
     | f >= 0    = setSecondFraction frcs t         >>= addSeconds secs
+    | frcs == 0 = setSecondFraction 0 t            >>= addSeconds secs
     | otherwise = setSecondFraction (frcs + 1.0) t >>= addSeconds (secs - 1)
     where
       f'   = f + (secondFraction t)

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -105,6 +105,8 @@ testTimeInstance t
         (addSecondFractions (-0.001) t >>= return . minute)         == Just 59 &&
         (addSecondFractions (-0.001) t >>= return . second)         == Just 59 &&
         (addSecondFractions (-0.001) t >>= return . secondFraction) == Just 0.999
+      , testProperty ("Subtracting 1.0s as fraction should result in -1 seconds")
+      $ (addSecondFractions (-1.0) t == addSeconds (-1) t `asTypeOf` Just t)
       ]
     ]
   where


### PR DESCRIPTION
If `frcs` was 0 previously, setSecondFraction would be called with `1.0` which resulted in an error.

Resolves #12.